### PR TITLE
Initialize React optimisation editor skeleton

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci && npm run build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# mo-editor
+# MO Editor
+
+This project is a lightweight optimisation model editor built with React 18, Vite and TypeScript. It runs entirely in the browser and can be deployed to GitHub Pages.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Deploy
+
+Push to `main` and GitHub Actions will build and publish the `dist` folder to GitHub Pages.
+
+## TODO
+- Switch to BrowserRouter + 404.html redirect for prettier URLs.
+- Replace brute-force with WebWorker-offloaded branch-and-bound.
+- Add backend (FastAPI + OR-Tools) for larger instances.
+- Natural-language → model AST converter feeding the same UI.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mo-editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0",
+    "react-dropzone": "^14.2.3",
+    "react-table": "^7.8.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MO Editor</title>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+</head>
+<body class="bg-gray-50">
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,21 @@
+import { Routes, Route, Link } from 'react-router-dom';
+import Home from './pages/Home';
+import KnapsackPage from './pages/KnapsackPage';
+import AssignmentPage from './pages/AssignmentPage';
+
+export default function App() {
+  return (
+    <div className="min-h-screen p-4 bg-gradient-to-br from-white to-cyan-50 text-gray-800">
+      <nav className="mb-4 space-x-4 text-teal-600">
+        <Link to="/">Home</Link>
+        <Link to="/knapsack">Knapsack</Link>
+        <Link to="/assignment">Assignment</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/knapsack" element={<KnapsackPage />} />
+        <Route path="/assignment" element={<AssignmentPage />} />
+      </Routes>
+    </div>
+  );
+}

--- a/src/builder/ConstraintTab.tsx
+++ b/src/builder/ConstraintTab.tsx
@@ -1,0 +1,9 @@
+export default function ConstraintTab() {
+  // TODO constraint table UI
+  return (
+    <div className="p-4 bg-white/60 rounded-lg shadow">
+      <h3 className="font-semibold">Constraints</h3>
+      <p>Define constraints here.</p>
+    </div>
+  );
+}

--- a/src/builder/ObjectiveTab.tsx
+++ b/src/builder/ObjectiveTab.tsx
@@ -1,0 +1,9 @@
+export default function ObjectiveTab() {
+  // TODO objective editor with Monaco
+  return (
+    <div className="p-4 bg-white/60 rounded-lg shadow">
+      <h3 className="font-semibold">Objective</h3>
+      <p>Objective editor placeholder.</p>
+    </div>
+  );
+}

--- a/src/builder/VariableTab.tsx
+++ b/src/builder/VariableTab.tsx
@@ -1,0 +1,9 @@
+export default function VariableTab() {
+  // TODO variable table UI
+  return (
+    <div className="p-4 bg-white/60 rounded-lg shadow">
+      <h3 className="font-semibold">Variables</h3>
+      <p>Define variables here.</p>
+    </div>
+  );
+}

--- a/src/components/EditableTable.tsx
+++ b/src/components/EditableTable.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import { useTable } from 'react-table';
+
+interface Props {
+  data: any[];
+  columns: any[];
+}
+
+export default function EditableTable({ data, columns }: Props) {
+  const memoData = useMemo(() => data, [data]);
+  const memoCols = useMemo(() => columns, [columns]);
+  const tableInstance = useTable({ columns: memoCols, data: memoData });
+  const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow } = tableInstance;
+
+  return (
+    <table {...getTableProps()} className="min-w-full text-sm text-left">
+      <thead className="bg-gray-100">
+        {headerGroups.map(group => (
+          <tr {...group.getHeaderGroupProps()}>
+            {group.headers.map(column => (
+              <th {...column.getHeaderProps()} className="p-2 font-semibold">{column.render('Header')}</th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody {...getTableBodyProps()}>
+        {rows.map(row => {
+          prepareRow(row);
+          return (
+            <tr {...row.getRowProps()} className="border-b last:border-b-0">
+              {row.cells.map(cell => (
+                <td {...cell.getCellProps()} className="p-2">{cell.render('Cell')}</td>
+              ))}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+interface Props {
+  model: 'knapsack' | 'assignment';
+}
+
+export default function FileUploader({ model }: Props) {
+  const onDrop = useCallback((accepted: File[]) => {
+    // TODO parse CSV and store in context
+    console.log('files', accepted);
+  }, []);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, accept: { 'text/csv': ['.csv'] } });
+
+  return (
+    <div {...getRootProps()} className={`p-4 border-2 border-dashed rounded-lg ${isDragActive ? 'bg-cyan-50' : ''}`}> 
+      <input {...getInputProps()} />
+      {isDragActive ? <p>Drop the CSV here...</p> : <p>Drag & drop CSV file here, or click to select</p>}
+    </div>
+  );
+}

--- a/src/components/ResultPanel.tsx
+++ b/src/components/ResultPanel.tsx
@@ -1,0 +1,9 @@
+export default function ResultPanel() {
+  // TODO show solution and allow CSV download
+  return (
+    <div className="p-4 rounded-lg shadow bg-white/60 backdrop-blur">
+      <h3 className="font-semibold">Results</h3>
+      <p>No solution yet.</p>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { HashRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <HashRouter>
+      <App />
+    </HashRouter>
+  </React.StrictMode>
+);

--- a/src/models/assignment.ts
+++ b/src/models/assignment.ts
@@ -1,0 +1,31 @@
+export type Matrix = number[][];
+
+export function parseAssignmentCSV(text: string): Matrix {
+  return text.trim().split(/\r?\n/).map(line => line.split(',').map(Number));
+}
+
+function permute(arr: number[]): number[][] {
+  if (arr.length === 1) return [arr];
+  const res: number[][] = [];
+  for (let i = 0; i < arr.length; i++) {
+    const rest = arr.slice(0, i).concat(arr.slice(i + 1));
+    for (const p of permute(rest)) res.push([arr[i], ...p]);
+  }
+  return res;
+}
+
+export function solveAssignment(mat: Matrix) {
+  const n = mat.length;
+  const cols = Array.from({ length: n }, (_, i) => i);
+  let best = Infinity;
+  let bestAssign: number[] = [];
+  for (const p of permute(cols)) {
+    let cost = 0;
+    for (let i = 0; i < n; i++) cost += mat[i][p[i]];
+    if (cost < best) {
+      best = cost;
+      bestAssign = p;
+    }
+  }
+  return { cost: best, assignment: bestAssign };
+}

--- a/src/models/knapsack.ts
+++ b/src/models/knapsack.ts
@@ -1,0 +1,39 @@
+export interface Item { name: string; weight: number; value: number; }
+export interface KnapsackData { items: Item[]; maxWeight: number; }
+
+export function parseKnapsackCSV(text: string): KnapsackData {
+  const lines = text.trim().split(/\r?\n/);
+  const items: Item[] = [];
+  let maxWeight = 0;
+  for (const line of lines) {
+    const [name, weight, value] = line.split(',');
+    if (name === '_max_weight') {
+      maxWeight = Number(weight);
+    } else {
+      items.push({ name, weight: Number(weight), value: Number(value) });
+    }
+  }
+  return { items, maxWeight };
+}
+
+export function solveKnapsack(data: KnapsackData) {
+  const n = data.items.length;
+  let bestValue = 0;
+  let bestSet: number[] = [];
+  for (let mask = 0; mask < 1 << n; mask++) {
+    let w = 0;
+    let v = 0;
+    for (let i = 0; i < n; i++) {
+      if (mask & (1 << i)) {
+        w += data.items[i].weight;
+        v += data.items[i].value;
+      }
+    }
+    if (w <= data.maxWeight && v > bestValue) {
+      bestValue = v;
+      bestSet = [];
+      for (let i = 0; i < n; i++) if (mask & (1 << i)) bestSet.push(i);
+    }
+  }
+  return { value: bestValue, selected: bestSet.map(i => data.items[i].name) };
+}

--- a/src/pages/AssignmentPage.tsx
+++ b/src/pages/AssignmentPage.tsx
@@ -1,0 +1,18 @@
+import FileUploader from '../components/FileUploader';
+import ResultPanel from '../components/ResultPanel';
+import VariableTab from '../builder/VariableTab';
+import ObjectiveTab from '../builder/ObjectiveTab';
+import ConstraintTab from '../builder/ConstraintTab';
+
+export default function AssignmentPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-navy">Assignment Problem</h2>
+      <FileUploader model="assignment" />
+      <VariableTab />
+      <ObjectiveTab />
+      <ConstraintTab />
+      <ResultPanel />
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div className="space-y-2">
+      <h1 className="text-2xl font-bold text-teal-700">MO Editor</h1>
+      <p>Build and solve small optimisation models directly in your browser.</p>
+    </div>
+  );
+}

--- a/src/pages/KnapsackPage.tsx
+++ b/src/pages/KnapsackPage.tsx
@@ -1,0 +1,18 @@
+import FileUploader from '../components/FileUploader';
+import ResultPanel from '../components/ResultPanel';
+import VariableTab from '../builder/VariableTab';
+import ObjectiveTab from '../builder/ObjectiveTab';
+import ConstraintTab from '../builder/ConstraintTab';
+
+export default function KnapsackPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-navy">Knapsack Problem</h2>
+      <FileUploader model="knapsack" />
+      <VariableTab />
+      <ObjectiveTab />
+      <ConstraintTab />
+      <ResultPanel />
+    </div>
+  );
+}

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,19 @@
+export const palette = {
+  primary: '#5CA6B0',
+  accent: '#32527B',
+  gray: '#A1A3A6'
+};
+
+export default {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        teal: { DEFAULT: palette.primary },
+        navy: { DEFAULT: palette.accent },
+        gray: { DEFAULT: palette.gray }
+      }
+    }
+  },
+  plugins: []
+};

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,2 @@
+const config = require('./src/theme').default;
+module.exports = config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/mo-editor/',
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- set up Vite + React + TypeScript project
- add Tailwind theme and basic pages/components
- implement simple knapsack and assignment solvers
- configure GitHub Actions to deploy to GitHub Pages
- add MIT license and project README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520967d104832687b72f0637fe71b8