### PR TITLE
Fix Vite build path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   base: '/mo-editor/',
+  root: 'public',
   plugins: [react()]
 });


### PR DESCRIPTION
## Summary
- configure Vite to look for `index.html` inside the `public` folder

## Testing
- `npm run build` *(fails: vite not found because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_685211949cc08326bf20922ba2f2d7e1