### PR TITLE
Fix gh-pages deploy permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,8 @@ name: Deploy
 on:
   push:
     branches: [ main ]
+permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- fix permission for GitHub Actions so it can push to `gh-pages`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68521794eeb883269a1c828d5172a107