### PR TITLE
Fix CSV import handling

### DIFF
--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -1,15 +1,29 @@
 import { useCallback } from 'react';
 import { useDropzone } from 'react-dropzone';
 
+import { parseKnapsackCSV } from '../models/knapsack';
+import { parseAssignmentCSV } from '../models/assignment';
+
 interface Props {
   model: 'knapsack' | 'assignment';
+  onData: (data: any) => void;
 }
 
-export default function FileUploader({ model }: Props) {
-  const onDrop = useCallback((accepted: File[]) => {
-    // TODO parse CSV and store in context
-    console.log('files', accepted);
-  }, []);
+export default function FileUploader({ model, onData }: Props) {
+  const onDrop = useCallback(
+    (accepted: File[]) => {
+      const file = accepted[0];
+      if (!file) return;
+      file.text().then(text => {
+        const data =
+          model === 'knapsack'
+            ? parseKnapsackCSV(text)
+            : parseAssignmentCSV(text);
+        onData(data);
+      });
+    },
+    [model, onData]
+  );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop, accept: { 'text/csv': ['.csv'] } });
 

--- a/src/components/ResultPanel.tsx
+++ b/src/components/ResultPanel.tsx
@@ -1,9 +1,38 @@
-export default function ResultPanel() {
-  // TODO show solution and allow CSV download
+export interface KnapsackSolution {
+  value: number;
+  selected: string[];
+}
+
+export interface AssignmentSolution {
+  cost: number;
+  assignment: number[];
+}
+
+export type Solution = KnapsackSolution | AssignmentSolution;
+
+interface Props {
+  solution: Solution | null;
+}
+
+export default function ResultPanel({ solution }: Props) {
   return (
     <div className="p-4 rounded-lg shadow bg-white/60 backdrop-blur">
       <h3 className="font-semibold">Results</h3>
-      <p>No solution yet.</p>
+      {solution ? (
+        'value' in solution ? (
+          <div>
+            <p>Best value: {solution.value}</p>
+            <p>Selected: {solution.selected.join(', ') || '-'}</p>
+          </div>
+        ) : (
+          <div>
+            <p>Best cost: {solution.cost}</p>
+            <p>Assignment: {solution.assignment.join(', ')}</p>
+          </div>
+        )
+      ) : (
+        <p>No solution yet.</p>
+      )}
     </div>
   );
 }

--- a/src/pages/AssignmentPage.tsx
+++ b/src/pages/AssignmentPage.tsx
@@ -1,18 +1,26 @@
+import { useState } from 'react';
 import FileUploader from '../components/FileUploader';
 import ResultPanel from '../components/ResultPanel';
 import VariableTab from '../builder/VariableTab';
 import ObjectiveTab from '../builder/ObjectiveTab';
 import ConstraintTab from '../builder/ConstraintTab';
+import { Matrix, solveAssignment } from '../models/assignment';
 
 export default function AssignmentPage() {
+  const [solution, setSolution] = useState<ReturnType<typeof solveAssignment> | null>(null);
+
+  const handleData = (mat: Matrix) => {
+    setSolution(solveAssignment(mat));
+  };
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold text-navy">Assignment Problem</h2>
-      <FileUploader model="assignment" />
+      <FileUploader model="assignment" onData={handleData} />
       <VariableTab />
       <ObjectiveTab />
       <ConstraintTab />
-      <ResultPanel />
+      <ResultPanel solution={solution} />
     </div>
   );
 }

--- a/src/pages/KnapsackPage.tsx
+++ b/src/pages/KnapsackPage.tsx
@@ -1,18 +1,39 @@
+import { useMemo, useState } from 'react';
 import FileUploader from '../components/FileUploader';
 import ResultPanel from '../components/ResultPanel';
+import EditableTable from '../components/EditableTable';
 import VariableTab from '../builder/VariableTab';
 import ObjectiveTab from '../builder/ObjectiveTab';
 import ConstraintTab from '../builder/ConstraintTab';
+import { KnapsackData, solveKnapsack } from '../models/knapsack';
 
 export default function KnapsackPage() {
+  const [data, setData] = useState<KnapsackData | null>(null);
+  const [solution, setSolution] = useState<ReturnType<typeof solveKnapsack> | null>(null);
+
+  const handleData = (d: KnapsackData) => {
+    setData(d);
+    setSolution(solveKnapsack(d));
+  };
+
+  const columns = useMemo(
+    () => [
+      { Header: 'Name', accessor: 'name' },
+      { Header: 'Weight', accessor: 'weight' },
+      { Header: 'Value', accessor: 'value' }
+    ],
+    []
+  );
+
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold text-navy">Knapsack Problem</h2>
-      <FileUploader model="knapsack" />
+      <FileUploader model="knapsack" onData={handleData} />
+      {data && <EditableTable data={data.items} columns={columns} />}
       <VariableTab />
       <ObjectiveTab />
       <ConstraintTab />
-      <ResultPanel />
+      <ResultPanel solution={solution} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- parse CSV uploads in FileUploader
- show uploaded items and computed solution on Knapsack page
- compute solution for Assignment instances
- display solutions in the Result panel

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68521c062354832694029e6645f4dbf9