### PR TITLE
Implement LP builder UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+package-lock.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,14 @@ import { Routes, Route, Link } from 'react-router-dom';
 import Home from './pages/Home';
 import KnapsackPage from './pages/KnapsackPage';
 import AssignmentPage from './pages/AssignmentPage';
+import BuilderPage from './pages/BuilderPage';
 
 export default function App() {
   return (
     <div className="min-h-screen p-4 bg-gradient-to-br from-white to-cyan-50 text-gray-800">
       <nav className="mb-4 space-x-4 text-teal-600">
         <Link to="/">Home</Link>
+        <Link to="/builder">Builder</Link>
         <Link to="/knapsack">Knapsack</Link>
         <Link to="/assignment">Assignment</Link>
       </nav>
@@ -15,6 +17,7 @@ export default function App() {
         <Route path="/" element={<Home />} />
         <Route path="/knapsack" element={<KnapsackPage />} />
         <Route path="/assignment" element={<AssignmentPage />} />
+        <Route path="/builder" element={<BuilderPage />} />
       </Routes>
     </div>
   );

--- a/src/builder/ConstraintTab.tsx
+++ b/src/builder/ConstraintTab.tsx
@@ -1,9 +1,43 @@
-export default function ConstraintTab() {
-  // TODO constraint table UI
+import { useState } from 'react';
+
+export interface ConstraintDef {
+  lhs: string;
+  comp: '<=' | '=' | '>=';
+  rhs: string;
+}
+
+interface Props {
+  constraints: ConstraintDef[];
+  onChange: (c: ConstraintDef[]) => void;
+}
+
+export default function ConstraintTab({ constraints, onChange }: Props) {
+  const [form, setForm] = useState<ConstraintDef>({ lhs: '', comp: '<=', rhs: '' });
+
+  const addConst = () => {
+    if (!form.lhs || !form.rhs) return;
+    onChange([...constraints, form]);
+    setForm({ lhs: '', comp: '<=', rhs: '' });
+  };
+
   return (
-    <div className="p-4 bg-white/60 rounded-lg shadow">
+    <div className="p-4 bg-white/60 rounded-lg shadow space-y-2">
       <h3 className="font-semibold">Constraints</h3>
-      <p>Define constraints here.</p>
+      <div className="flex items-end space-x-2 flex-wrap">
+        <input value={form.lhs} onChange={e => setForm({ ...form, lhs: e.target.value })} className="flex-grow p-1 border rounded" placeholder="Left-hand expression" />
+        <select value={form.comp} onChange={e => setForm({ ...form, comp: e.target.value as ConstraintDef['comp'] })} className="p-1 border rounded">
+          <option value="<=">&le;</option>
+          <option value="=">=</option>
+          <option value=">=">&ge;</option>
+        </select>
+        <input value={form.rhs} onChange={e => setForm({ ...form, rhs: e.target.value })} className="flex-grow p-1 border rounded" placeholder="Right-hand expression" />
+        <button onClick={addConst} className="px-2 py-1 rounded bg-teal text-white">Add</button>
+      </div>
+      <ul className="list-disc ml-4">
+        {constraints.map((c, idx) => (
+          <li key={idx}>{c.lhs} {c.comp} {c.rhs}</li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/builder/ObjectiveTab.tsx
+++ b/src/builder/ObjectiveTab.tsx
@@ -1,9 +1,19 @@
-export default function ObjectiveTab() {
-  // TODO objective editor with Monaco
+interface Objective {
+  sense: 'max' | 'min';
+  expr: string;
+}
+
+export default function ObjectiveTab({ objective, onChange }: { objective: Objective; onChange: (o: Objective) => void }) {
   return (
-    <div className="p-4 bg-white/60 rounded-lg shadow">
+    <div className="p-4 bg-white/60 rounded-lg shadow space-y-2">
       <h3 className="font-semibold">Objective</h3>
-      <p>Objective editor placeholder.</p>
+      <div className="flex items-center space-x-2">
+        <select value={objective.sense} onChange={e => onChange({ ...objective, sense: e.target.value as Objective['sense'] })} className="p-1 border rounded">
+          <option value="max">Maximize</option>
+          <option value="min">Minimize</option>
+        </select>
+        <input value={objective.expr} onChange={e => onChange({ ...objective, expr: e.target.value })} className="flex-grow p-1 border rounded" placeholder="e.g. sum_i c[i] x[i]" />
+      </div>
     </div>
   );
 }

--- a/src/builder/ParameterTab.tsx
+++ b/src/builder/ParameterTab.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+import { SetDef } from './SetTab';
+
+export interface ParamDef {
+  name: string;
+  set: string | null; // null for scalar
+  values: string[]; // raw CSV rows or single scalar
+}
+
+interface Props {
+  params: ParamDef[];
+  onChange: (p: ParamDef[]) => void;
+  sets: SetDef[];
+}
+
+export default function ParameterTab({ params, onChange, sets }: Props) {
+  const [name, setName] = useState('');
+  const [setNameSel, setSetNameSel] = useState<string>('');
+  const [val, setVal] = useState('');
+
+  const addScalar = () => {
+    if (!name) return;
+    onChange([...params, { name, set: setNameSel || null, values: [val] }]);
+    setName('');
+    setVal('');
+  };
+
+  const handleFile = (files: FileList | null) => {
+    if (!files || !files[0]) return;
+    files[0].text().then(text => {
+      const values = text.trim().split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+      onChange([...params, { name, set: setNameSel, values }]);
+      setName('');
+      setVal('');
+    });
+  };
+
+  return (
+    <div className="p-4 bg-white/60 rounded-lg shadow space-y-2">
+      <h3 className="font-semibold">Parameters</h3>
+      <div className="flex items-end space-x-2 flex-wrap">
+        <div>
+          <label className="block text-sm">Name</label>
+          <input value={name} onChange={e => setName(e.target.value)} className="p-1 border rounded" />
+        </div>
+        <div>
+          <label className="block text-sm">Index Set</label>
+          <select value={setNameSel} onChange={e => setSetNameSel(e.target.value)} className="p-1 border rounded">
+            <option value="">(scalar)</option>
+            {sets.map(s => (
+              <option key={s.name} value={s.name}>{s.name}</option>
+            ))}
+          </select>
+        </div>
+        {setNameSel ? (
+          <div>
+            <label className="block text-sm">Values CSV</label>
+            <input type="file" accept=".csv" onChange={e => handleFile(e.target.files)} />
+          </div>
+        ) : (
+          <div>
+            <label className="block text-sm">Value</label>
+            <input value={val} onChange={e => setVal(e.target.value)} className="p-1 border rounded" />
+          </div>
+        )}
+        <button onClick={addScalar} className="px-2 py-1 rounded bg-teal text-white">Add</button>
+      </div>
+      <ul className="list-disc ml-4">
+        {params.map((p, idx) => (
+          <li key={idx}>{p.name}{p.set ? `[${p.set}]` : ''}: {p.values.join(', ')}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/builder/Preview.tsx
+++ b/src/builder/Preview.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { SetDef } from './SetTab';
+import { ParamDef } from './ParameterTab';
+import { VarDef } from './VariableTab';
+import { ConstraintDef } from './ConstraintTab';
+
+interface Props {
+  sets: SetDef[];
+  params: ParamDef[];
+  vars: VarDef[];
+  objective: { sense: 'max' | 'min'; expr: string };
+  constraints: ConstraintDef[];
+}
+
+export default function Preview({ sets, params, vars, objective, constraints }: Props) {
+  const latex = `\\begin{align}\n` +
+    sets.map(s => `${s.name} &= \{${s.members.join(', ')}\}`).join('\\\\\n') +
+    (sets.length ? '\\\n' : '') +
+    params.map(p => `${p.name}${p.set ? `_{${p.set}}` : ''} &= ${p.values.join(', ')}`).join('\\\\\n') +
+    (params.length ? '\\\n' : '') +
+    `${objective.sense === 'max' ? 'max' : 'min'} && ${objective.expr} \\` +
+    vars.map(v => `${v.name}${v.index ? `_{${v.index}}` : ''} ${v.lb || v.ub ? `\\in [${v.lb || '-\\infty'}, ${v.ub || '+\\infty'}]` : ''}`).join('\\\\\n') +
+    (vars.length ? '\\\n' : '') +
+    constraints.map(c => `${c.lhs} ${c.comp} ${c.rhs}`).join('\\\\\n') +
+    '\\end{align}';
+
+  useEffect(() => {
+    if ((window as any).MathJax) (window as any).MathJax.typeset();
+  }, [latex]);
+
+  return (
+    <div className="p-4 bg-white/60 rounded-lg shadow">
+      <h3 className="font-semibold mb-2">Preview</h3>
+      <div className="overflow-x-auto">{latex ? <div dangerouslySetInnerHTML={{ __html: `$$${latex}$$` }} /> : <p>No model yet.</p>}</div>
+    </div>
+  );
+}

--- a/src/builder/SetTab.tsx
+++ b/src/builder/SetTab.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+export interface SetDef {
+  name: string;
+  members: string[];
+}
+
+export default function SetTab({ sets, onChange }: { sets: SetDef[]; onChange: (s: SetDef[]) => void }) {
+  const [name, setName] = useState('');
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  const addSet = (members: string[]) => {
+    onChange([...sets, { name, members }]);
+    setName('');
+  };
+
+  const handleFile = (files: FileList | null) => {
+    if (!files || !files[0]) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      const members = text.trim().split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+      addSet(members);
+    };
+    reader.onerror = () => {
+      setFileError('Failed to read file');
+    };
+    reader.readAsText(files[0]);
+  };
+
+  return (
+    <div className="p-4 bg-white/60 rounded-lg shadow space-y-2">
+      <h3 className="font-semibold">Sets</h3>
+      <div className="flex items-end space-x-2">
+        <div>
+          <label className="block text-sm">Name</label>
+          <input value={name} onChange={e => setName(e.target.value)} className="p-1 border rounded" />
+        </div>
+        <div>
+          <label className="block text-sm">Members CSV</label>
+          <input type="file" accept=".csv" onChange={e => handleFile(e.target.files)} />
+        </div>
+      </div>
+      {fileError && <p className="text-red-600 text-sm">{fileError}</p>}
+      <ul className="list-disc ml-4">
+        {sets.map((s, idx) => (
+          <li key={idx}>{s.name}: {s.members.join(', ')}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/builder/VariableTab.tsx
+++ b/src/builder/VariableTab.tsx
@@ -1,9 +1,86 @@
-export default function VariableTab() {
-  // TODO variable table UI
+import { useState } from 'react';
+import { SetDef } from './SetTab';
+
+export interface VarDef {
+  name: string;
+  index: string | null;
+  type: 'continuous' | 'integer' | 'binary';
+  lb: string;
+  ub: string;
+}
+
+interface Props {
+  vars: VarDef[];
+  onChange: (v: VarDef[]) => void;
+  sets: SetDef[];
+}
+
+export default function VariableTab({ vars, onChange, sets }: Props) {
+  const [form, setForm] = useState<VarDef>({ name: '', index: null, type: 'continuous', lb: '', ub: '' });
+
+  const addVar = () => {
+    if (!form.name) return;
+    onChange([...vars, form]);
+    setForm({ name: '', index: null, type: 'continuous', lb: '', ub: '' });
+  };
+
   return (
-    <div className="p-4 bg-white/60 rounded-lg shadow">
+    <div className="p-4 bg-white/60 rounded-lg shadow space-y-2">
       <h3 className="font-semibold">Variables</h3>
-      <p>Define variables here.</p>
+      <div className="flex items-end space-x-2 flex-wrap">
+        <div>
+          <label className="block text-sm">Name</label>
+          <input value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} className="p-1 border rounded" />
+        </div>
+        <div>
+          <label className="block text-sm">Index Set</label>
+          <select value={form.index || ''} onChange={e => setForm({ ...form, index: e.target.value || null })} className="p-1 border rounded">
+            <option value="">(scalar)</option>
+            {sets.map(s => (
+              <option key={s.name} value={s.name}>{s.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm">Type</label>
+          <select value={form.type} onChange={e => setForm({ ...form, type: e.target.value as VarDef['type'] })} className="p-1 border rounded">
+            <option value="continuous">Continuous</option>
+            <option value="integer">Integer</option>
+            <option value="binary">Binary</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm">LB</label>
+          <input value={form.lb} onChange={e => setForm({ ...form, lb: e.target.value })} className="p-1 border rounded w-20" />
+        </div>
+        <div>
+          <label className="block text-sm">UB</label>
+          <input value={form.ub} onChange={e => setForm({ ...form, ub: e.target.value })} className="p-1 border rounded w-20" />
+        </div>
+        <button onClick={addVar} className="px-2 py-1 rounded bg-teal text-white">Add</button>
+      </div>
+      <table className="min-w-full text-sm text-left">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="p-2">Name</th>
+            <th className="p-2">Index</th>
+            <th className="p-2">Type</th>
+            <th className="p-2">LB</th>
+            <th className="p-2">UB</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vars.map((v, idx) => (
+            <tr key={idx} className="border-b last:border-b-0">
+              <td className="p-2">{v.name}</td>
+              <td className="p-2">{v.index || '-'}</td>
+              <td className="p-2">{v.type}</td>
+              <td className="p-2">{v.lb}</td>
+              <td className="p-2">{v.ub}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/pages/AssignmentPage.tsx
+++ b/src/pages/AssignmentPage.tsx
@@ -1,9 +1,6 @@
 import { useState } from 'react';
 import FileUploader from '../components/FileUploader';
 import ResultPanel from '../components/ResultPanel';
-import VariableTab from '../builder/VariableTab';
-import ObjectiveTab from '../builder/ObjectiveTab';
-import ConstraintTab from '../builder/ConstraintTab';
 import { Matrix, solveAssignment } from '../models/assignment';
 
 export default function AssignmentPage() {
@@ -17,9 +14,6 @@ export default function AssignmentPage() {
     <div className="space-y-4">
       <h2 className="text-xl font-semibold text-navy">Assignment Problem</h2>
       <FileUploader model="assignment" onData={handleData} />
-      <VariableTab />
-      <ObjectiveTab />
-      <ConstraintTab />
       <ResultPanel solution={solution} />
     </div>
   );

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+import SetTab, { SetDef } from '../builder/SetTab';
+import ParameterTab, { ParamDef } from '../builder/ParameterTab';
+import VariableTab, { VarDef } from '../builder/VariableTab';
+import ObjectiveTab from '../builder/ObjectiveTab';
+import ConstraintTab, { ConstraintDef } from '../builder/ConstraintTab';
+import Preview from '../builder/Preview';
+
+export default function BuilderPage() {
+  const [sets, setSets] = useState<SetDef[]>([]);
+  const [params, setParams] = useState<ParamDef[]>([]);
+  const [vars, setVars] = useState<VarDef[]>([]);
+  const [objective, setObjective] = useState<{ sense: 'max' | 'min'; expr: string }>({ sense: 'max', expr: '' });
+  const [constraints, setConstraints] = useState<ConstraintDef[]>([]);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold text-navy">Model Builder</h2>
+      <SetTab sets={sets} onChange={setSets} />
+      <ParameterTab params={params} onChange={setParams} sets={sets} />
+      <VariableTab vars={vars} onChange={setVars} sets={sets} />
+      <ObjectiveTab objective={objective} onChange={setObjective} />
+      <ConstraintTab constraints={constraints} onChange={setConstraints} />
+      <Preview sets={sets} params={params} vars={vars} objective={objective} constraints={constraints} />
+    </div>
+  );
+}

--- a/src/pages/KnapsackPage.tsx
+++ b/src/pages/KnapsackPage.tsx
@@ -2,9 +2,6 @@ import { useMemo, useState } from 'react';
 import FileUploader from '../components/FileUploader';
 import ResultPanel from '../components/ResultPanel';
 import EditableTable from '../components/EditableTable';
-import VariableTab from '../builder/VariableTab';
-import ObjectiveTab from '../builder/ObjectiveTab';
-import ConstraintTab from '../builder/ConstraintTab';
 import { KnapsackData, solveKnapsack } from '../models/knapsack';
 
 export default function KnapsackPage() {
@@ -30,9 +27,6 @@ export default function KnapsackPage() {
       <h2 className="text-xl font-semibold text-navy">Knapsack Problem</h2>
       <FileUploader model="knapsack" onData={handleData} />
       {data && <EditableTable data={data.items} columns={columns} />}
-      <VariableTab />
-      <ObjectiveTab />
-      <ConstraintTab />
       <ResultPanel solution={solution} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add Model Builder page with Sets, Parameters, Variables, Objective and Constraints
- render live LaTeX preview of current model
- update navigation and routes
- strip placeholder components from sample pages
- ignore build artifacts and dependencies

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68522052bb748326b2022e415438e1c1