### PR TITLE
Fix Preview newline issue

### DIFF
--- a/src/builder/Preview.tsx
+++ b/src/builder/Preview.tsx
@@ -18,7 +18,7 @@ export default function Preview({ sets, params, vars, objective, constraints }: 
     (sets.length ? '\n' : '') +
     params.map(p => `${p.name}${p.set ? `_{${p.set}}` : ''} &= ${p.values.join(', ')}`).join('\\\\\n') +
     (params.length ? '\n' : '') +
-    `${objective.sense === 'max' ? 'max' : 'min'} && ${objective.expr} \\` +
+    `${objective.sense === 'max' ? 'max' : 'min'} && ${objective.expr} \\\n` +
     vars.map(v => `${v.name}${v.index ? `_{${v.index}}` : ''} ${v.lb || v.ub ? `\\in [${v.lb || '-\\infty'}, ${v.ub || '+\\infty'}]` : ''}`).join('\\\\\n') +
     (vars.length ? '\n' : '') +
     constraints.map(c => `${c.lhs} ${c.comp} ${c.rhs}`).join('\\\\\n') +


### PR DESCRIPTION
## Summary
- ensure the objective line in the preview ends with a newline so variables start on a new line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68522afd20a08326aa5e10f8c3943f2b