### PR TITLE
Add summation widget and improve preview

### DIFF
--- a/src/builder/ConstraintTab.tsx
+++ b/src/builder/ConstraintTab.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import SummationWidget from './SummationWidget';
+import { SetDef } from './SetTab';
 
 export interface ConstraintDef {
   lhs: string;
@@ -9,9 +11,10 @@ export interface ConstraintDef {
 interface Props {
   constraints: ConstraintDef[];
   onChange: (c: ConstraintDef[]) => void;
+  sets: SetDef[];
 }
 
-export default function ConstraintTab({ constraints, onChange }: Props) {
+export default function ConstraintTab({ constraints, onChange, sets }: Props) {
   const [form, setForm] = useState<ConstraintDef>({ lhs: '', comp: '<=', rhs: '' });
 
   const addConst = () => {
@@ -33,6 +36,8 @@ export default function ConstraintTab({ constraints, onChange }: Props) {
         <input value={form.rhs} onChange={e => setForm({ ...form, rhs: e.target.value })} className="flex-grow p-1 border rounded" placeholder="Right-hand expression" />
         <button onClick={addConst} className="px-2 py-1 rounded bg-teal text-white">Add</button>
       </div>
+      <SummationWidget sets={sets} onInsert={expr => setForm(f => ({ ...f, lhs: f.lhs ? f.lhs + ' ' + expr : expr }))} />
+      <SummationWidget sets={sets} onInsert={expr => setForm(f => ({ ...f, rhs: f.rhs ? f.rhs + ' ' + expr : expr }))} />
       <ul className="list-disc ml-4">
         {constraints.map((c, idx) => (
           <li key={idx}>{c.lhs} {c.comp} {c.rhs}</li>

--- a/src/builder/ObjectiveTab.tsx
+++ b/src/builder/ObjectiveTab.tsx
@@ -1,9 +1,18 @@
+import SummationWidget from './SummationWidget';
+import { SetDef } from './SetTab';
+
 interface Objective {
   sense: 'max' | 'min';
   expr: string;
 }
 
-export default function ObjectiveTab({ objective, onChange }: { objective: Objective; onChange: (o: Objective) => void }) {
+interface Props {
+  objective: Objective;
+  onChange: (o: Objective) => void;
+  sets: SetDef[];
+}
+
+export default function ObjectiveTab({ objective, onChange, sets }: Props) {
   return (
     <div className="p-4 bg-white/60 rounded-lg shadow space-y-2">
       <h3 className="font-semibold">Objective</h3>
@@ -14,6 +23,7 @@ export default function ObjectiveTab({ objective, onChange }: { objective: Objec
         </select>
         <input value={objective.expr} onChange={e => onChange({ ...objective, expr: e.target.value })} className="flex-grow p-1 border rounded" placeholder="e.g. sum_i c[i] x[i]" />
       </div>
+      <SummationWidget sets={sets} onInsert={expr => onChange({ ...objective, expr: (objective.expr ? objective.expr + ' ' : '') + expr })} />
     </div>
   );
 }

--- a/src/builder/Preview.tsx
+++ b/src/builder/Preview.tsx
@@ -13,16 +13,14 @@ interface Props {
 }
 
 export default function Preview({ sets, params, vars, objective, constraints }: Props) {
-  const latex = `\\begin{align}\n` +
-    sets.map(s => `${s.name} &= \{${s.members.join(', ')}\}`).join('\\\\\n') +
-    (sets.length ? '\n' : '') +
-    params.map(p => `${p.name}${p.set ? `_{${p.set}}` : ''} &= ${p.values.join(', ')}`).join('\\\\\n') +
-    (params.length ? '\n' : '') +
-    `${objective.sense === 'max' ? 'max' : 'min'} && ${objective.expr} \\\n` +
-    vars.map(v => `${v.name}${v.index ? `_{${v.index}}` : ''} ${v.lb || v.ub ? `\\in [${v.lb || '-\\infty'}, ${v.ub || '+\\infty'}]` : ''}`).join('\\\\\n') +
-    (vars.length ? '\n' : '') +
-    constraints.map(c => `${c.lhs} ${c.comp} ${c.rhs}`).join('\\\\\n') +
-    '\\end{align}';
+  const lines: string[] = [];
+  lines.push(...sets.map(s => `${s.name} &= \{${s.members.join(', ')}\}`));
+  lines.push(...params.map(p => `${p.name}${p.set ? `_{${p.set}}` : ''} &= ${p.values.join(', ')}`));
+  lines.push(`${objective.sense === 'max' ? 'max' : 'min'} && ${objective.expr}`);
+  lines.push(...vars.map(v => `${v.name}${v.index ? `_{${v.index}}` : ''} ${v.lb || v.ub ? `\\in [${v.lb || '-\\infty'}, ${v.ub || '+\\infty'}]` : ''}`));
+  lines.push(...constraints.map(c => `${c.lhs} ${c.comp} ${c.rhs}`));
+
+  const latex = `\\begin{align}\n` + lines.map(l => `${l} \\`).join('\n') + '\n\\end{align}';
 
   useEffect(() => {
     if ((window as any).MathJax) (window as any).MathJax.typeset();

--- a/src/builder/SummationWidget.tsx
+++ b/src/builder/SummationWidget.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { SetDef } from './SetTab';
+
+interface Props {
+  sets: SetDef[];
+  onInsert: (expr: string) => void;
+}
+
+export default function SummationWidget({ sets, onInsert }: Props) {
+  const [indexVar, setIndexVar] = useState('');
+  const [setName, setSetName] = useState('');
+  const [body, setBody] = useState('');
+
+  const add = () => {
+    if (!indexVar || !setName || !body) return;
+    onInsert(`sum_{${indexVar} in ${setName}} ${body}`);
+    setIndexVar('');
+    setSetName('');
+    setBody('');
+  };
+
+  return (
+    <div className="flex items-end space-x-2 flex-wrap">
+      <div>
+        <label className="block text-sm">Index</label>
+        <input value={indexVar} onChange={e => setIndexVar(e.target.value)} className="p-1 border rounded w-16" />
+      </div>
+      <div>
+        <label className="block text-sm">Set</label>
+        <select value={setName} onChange={e => setSetName(e.target.value)} className="p-1 border rounded">
+          <option value="">Select</option>
+          {sets.map(s => (
+            <option key={s.name} value={s.name}>{s.name}</option>
+          ))}
+        </select>
+      </div>
+      <div className="flex-grow">
+        <label className="block text-sm">Expression</label>
+        <input value={body} onChange={e => setBody(e.target.value)} className="p-1 border rounded w-full" />
+      </div>
+      <button onClick={add} className="px-2 py-1 rounded bg-teal text-white">Insert</button>
+    </div>
+  );
+}

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -19,8 +19,8 @@ export default function BuilderPage() {
       <SetTab sets={sets} onChange={setSets} />
       <ParameterTab params={params} onChange={setParams} sets={sets} />
       <VariableTab vars={vars} onChange={setVars} sets={sets} />
-      <ObjectiveTab objective={objective} onChange={setObjective} />
-      <ConstraintTab constraints={constraints} onChange={setConstraints} />
+      <ObjectiveTab objective={objective} onChange={setObjective} sets={sets} />
+      <ConstraintTab constraints={constraints} onChange={setConstraints} sets={sets} />
       <Preview sets={sets} params={params} vars={vars} objective={objective} constraints={constraints} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add a `SummationWidget` component to bind index variables to sets
- support the widget in objectives and constraints
- show constraints in Preview and fix formatting
- pass sets down to builder tabs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68522d7bf474832691119ac28a363655