### PR TITLE
Add random solver for builder

### DIFF
--- a/src/components/GenericResultPanel.tsx
+++ b/src/components/GenericResultPanel.tsx
@@ -1,0 +1,23 @@
+import { GenericSolution } from '../models/randomSolve';
+
+export default function GenericResultPanel({ solution }: { solution: GenericSolution | null }) {
+  return (
+    <div className="p-4 rounded-lg shadow bg-white/60 backdrop-blur">
+      <h3 className="font-semibold">Results</h3>
+      {solution ? (
+        <ul className="list-disc ml-4">
+          {Object.entries(solution.vars).map(([name, val]) =>
+            typeof val === 'object' ? (
+              <li key={name}>{name}: {Object.entries(val).map(([k, v]) => `${k}:${v}`).join(', ')}</li>
+            ) : (
+              <li key={name}>{name}: {val}</li>
+            )
+          )}
+        </ul>
+      ) : (
+        <p>No solution yet.</p>
+      )}
+    </div>
+  );
+}
+

--- a/src/models/randomSolve.ts
+++ b/src/models/randomSolve.ts
@@ -1,0 +1,38 @@
+import { VarDef } from '../builder/VariableTab';
+import { SetDef } from '../builder/SetTab';
+
+export interface GenericSolution {
+  vars: Record<string, number | Record<string, number>>;
+}
+
+function randBetween(lb: number, ub: number, isInt: boolean): number {
+  const r = lb + Math.random() * (ub - lb);
+  return isInt ? Math.round(r) : parseFloat(r.toFixed(2));
+}
+
+export function randomSolve(vars: VarDef[], sets: SetDef[]): GenericSolution {
+  const result: Record<string, any> = {};
+  for (const v of vars) {
+    const lb = parseFloat(v.lb);
+    const ub = parseFloat(v.ub);
+    const hasLb = !isNaN(lb);
+    const hasUb = !isNaN(ub);
+    const lower = hasLb ? lb : 0;
+    const upper = hasUb ? ub : v.type === 'binary' ? 1 : 10;
+    const genValue = () => {
+      if (v.type === 'binary') return Math.random() < 0.5 ? 0 : 1;
+      return randBetween(lower, upper, v.type === 'integer');
+    };
+
+    if (v.index) {
+      const members = sets.find(s => s.name === v.index)?.members || [];
+      const indexed: Record<string, number> = {};
+      for (const m of members) indexed[m] = genValue();
+      result[v.name] = indexed;
+    } else {
+      result[v.name] = genValue();
+    }
+  }
+  return { vars: result };
+}
+

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -5,6 +5,8 @@ import VariableTab, { VarDef } from '../builder/VariableTab';
 import ObjectiveTab from '../builder/ObjectiveTab';
 import ConstraintTab, { ConstraintDef } from '../builder/ConstraintTab';
 import Preview from '../builder/Preview';
+import { randomSolve, GenericSolution } from '../models/randomSolve';
+import GenericResultPanel from '../components/GenericResultPanel';
 
 export default function BuilderPage() {
   const [sets, setSets] = useState<SetDef[]>([]);
@@ -12,6 +14,11 @@ export default function BuilderPage() {
   const [vars, setVars] = useState<VarDef[]>([]);
   const [objective, setObjective] = useState<{ sense: 'max' | 'min'; expr: string }>({ sense: 'max', expr: '' });
   const [constraints, setConstraints] = useState<ConstraintDef[]>([]);
+  const [solution, setSolution] = useState<GenericSolution | null>(null);
+
+  const calculate = () => {
+    setSolution(randomSolve(vars, sets));
+  };
 
   return (
     <div className="space-y-4">
@@ -34,6 +41,8 @@ export default function BuilderPage() {
         vars={vars}
       />
       <Preview sets={sets} params={params} vars={vars} objective={objective} constraints={constraints} />
+      <button onClick={calculate} className="px-4 py-2 rounded bg-teal text-white">Calculate</button>
+      <GenericResultPanel solution={solution} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- provide a tiny random solver to generate variable assignments
- add GenericResultPanel component
- show new Calculate button in the Builder page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852387fc1388326af709c5c2db66f59